### PR TITLE
feat(explore): Add ability to filter in explore plugin UI

### DIFF
--- a/workspaces/explore/.changeset/popular-starfishes-leave.md
+++ b/workspaces/explore/.changeset/popular-starfishes-leave.md
@@ -1,0 +1,5 @@
+---
+'@backstage-community/plugin-explore': minor
+---
+
+Add ability to optionally filter by tags and lifecycle

--- a/workspaces/explore/plugins/explore/report.api.md
+++ b/workspaces/explore/plugins/explore/report.api.md
@@ -133,6 +133,9 @@ export type SubRoute = {
 // @public (undocumented)
 export const ToolExplorerContent: (props: {
   title?: string | undefined;
+  objectFit?: 'contain' | 'cover' | undefined;
+  showTagsFilter?: boolean | undefined;
+  showLifecycleFilter?: boolean | undefined;
 }) => JSX_2.Element;
 
 // @public (undocumented)

--- a/workspaces/explore/plugins/explore/src/components/ToolExplorerContent/ToolExplorerContent.test.tsx
+++ b/workspaces/explore/plugins/explore/src/components/ToolExplorerContent/ToolExplorerContent.test.tsx
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
-import { ExploreTool } from '@backstage-community/plugin-explore-common';
+import {
+  ExploreTool,
+  GetExploreToolsRequest,
+} from '@backstage-community/plugin-explore-common';
 import { renderInTestApp, TestApiProvider } from '@backstage/test-utils';
-import { waitFor } from '@testing-library/react';
+import { waitFor, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { exploreApiRef } from '../../api';
 import { ToolExplorerContent } from './ToolExplorerContent';
@@ -24,6 +27,65 @@ import { ToolExplorerContent } from './ToolExplorerContent';
 describe('<ToolExplorerContent />', () => {
   const exploreApi: jest.Mocked<typeof exploreApiRef.T> = {
     getTools: jest.fn(),
+  };
+
+  const defaultTools: ExploreTool[] = [
+    {
+      title: 'Lighthouse',
+      description:
+        "Google's Lighthouse tool is a great resource for benchmarking and improving the accessibility, performance, SEO, and best practices of your website.",
+      url: '/lighthouse',
+      image:
+        'https://raw.githubusercontent.com/GoogleChrome/lighthouse/8b3d7f052b2e64dd857e741d7395647f487697e7/assets/lighthouse-logo.png',
+      tags: ['web', 'seo', 'accessibility', 'performance'],
+    },
+    {
+      title: 'Tech Radar',
+      description:
+        'Tech Radar is a list of technologies, complemented by an assessment result, called ring assignment.',
+      url: '/tech-radar',
+      image:
+        'https://storage.googleapis.com/wf-blogs-engineering-media/2018/09/fe13bb32-wf-tech-radar-hero-1024x597.png',
+      lifecycle: 'experimental',
+      tags: ['standards', 'landscape'],
+    },
+  ];
+
+  const defaultTagFilterFunction = async (request?: GetExploreToolsRequest) => {
+    if (
+      request &&
+      request.filter &&
+      request.filter.tags &&
+      request.filter.tags?.length > 0
+    ) {
+      const filteredTools = defaultTools.filter(tool => {
+        return tool.tags?.some(tag => request.filter?.tags?.includes(tag));
+      });
+
+      return { tools: filteredTools };
+    }
+    return { tools: defaultTools };
+  };
+
+  const defaultLifecycleFilterFunction = async (
+    request?: GetExploreToolsRequest,
+  ) => {
+    if (
+      request &&
+      request.filter &&
+      request.filter.lifecycle &&
+      request.filter.lifecycle?.length > 0
+    ) {
+      const filteredTools = defaultTools.filter(tool => {
+        if (!tool.lifecycle) {
+          return false;
+        }
+        return request.filter?.lifecycle?.includes(tool.lifecycle);
+      });
+
+      return { tools: filteredTools };
+    }
+    return { tools: defaultTools };
   };
 
   const Wrapper = ({ children }: { children?: React.ReactNode }) => (
@@ -37,27 +99,7 @@ describe('<ToolExplorerContent />', () => {
   });
 
   it('renders a grid of tools', async () => {
-    const tools: ExploreTool[] = [
-      {
-        title: 'Lighthouse',
-        description:
-          "Google's Lighthouse tool is a great resource for benchmarking and improving the accessibility, performance, SEO, and best practices of your website.",
-        url: '/lighthouse',
-        image:
-          'https://raw.githubusercontent.com/GoogleChrome/lighthouse/8b3d7f052b2e64dd857e741d7395647f487697e7/assets/lighthouse-logo.png',
-        tags: ['web', 'seo', 'accessibility', 'performance'],
-      },
-      {
-        title: 'Tech Radar',
-        description:
-          'Tech Radar is a list of technologies, complemented by an assessment result, called ring assignment.',
-        url: '/tech-radar',
-        image:
-          'https://storage.googleapis.com/wf-blogs-engineering-media/2018/09/fe13bb32-wf-tech-radar-hero-1024x597.png',
-        tags: ['standards', 'landscape'],
-      },
-    ];
-    exploreApi.getTools.mockResolvedValue({ tools });
+    exploreApi.getTools.mockImplementation(defaultTagFilterFunction);
 
     const { getByText } = await renderInTestApp(
       <Wrapper>
@@ -93,7 +135,146 @@ describe('<ToolExplorerContent />', () => {
     );
 
     await waitFor(() =>
-      expect(getByText('No tools to display')).toBeInTheDocument(),
+      expect(getByText('Warning: No tools found')).toBeInTheDocument(),
     );
+  });
+
+  it('does not show lifecycle and tags filter by default', async () => {
+    exploreApi.getTools.mockImplementation(defaultTagFilterFunction);
+
+    const { queryByText } = await renderInTestApp(
+      <Wrapper>
+        <ToolExplorerContent />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Tags')).not.toBeInTheDocument();
+      expect(queryByText('Lifecycle')).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows tags filter with correct options when showTagsFilter set', async () => {
+    exploreApi.getTools.mockImplementation(defaultTagFilterFunction);
+
+    const { getAllByRole, getByTestId } = await renderInTestApp(
+      <Wrapper>
+        <ToolExplorerContent showTagsFilter />
+      </Wrapper>,
+    );
+
+    fireEvent.click(getByTestId('tag-picker-expand'));
+    await waitFor(() => {
+      expect(getAllByRole('option').map(o => o.textContent)).toEqual([
+        'web',
+        'seo',
+        'accessibility',
+        'performance',
+        'standards',
+        'landscape',
+      ]);
+    });
+  });
+
+  it('filters by tags and updates tools displayed', async () => {
+    exploreApi.getTools.mockImplementation(defaultTagFilterFunction);
+
+    const { getByText, getByTestId, getByRole, queryByText } =
+      await renderInTestApp(
+        <Wrapper>
+          <ToolExplorerContent showTagsFilter />
+        </Wrapper>,
+      );
+
+    await waitFor(() => {
+      expect(getByText('Lighthouse')).toBeInTheDocument();
+      expect(getByText('Tech Radar')).toBeInTheDocument();
+    });
+
+    fireEvent.click(getByTestId('tag-picker-expand'));
+    fireEvent.click(getByRole('option', { name: 'landscape' }));
+
+    await waitFor(() => {
+      expect(getByRole('button', { name: 'landscape' })).toBeInTheDocument();
+      expect(getByText('Tech Radar')).toBeInTheDocument();
+      expect(queryByText('Lighthouse')).not.toBeInTheDocument();
+    });
+  });
+
+  it('uses query param to populate tag filter', async () => {
+    exploreApi.getTools.mockImplementation(defaultTagFilterFunction);
+    jest
+      .spyOn(URLSearchParams.prototype, 'getAll')
+      .mockReturnValue(['landscape']);
+
+    const { getByText, queryByText } = await renderInTestApp(
+      <Wrapper>
+        <ToolExplorerContent showTagsFilter />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Lighthouse')).not.toBeInTheDocument();
+      expect(getByText('Tech Radar')).toBeInTheDocument();
+    });
+  });
+
+  it('shows lifecycle filter with correct options when showLifeCycleFilter set', async () => {
+    exploreApi.getTools.mockImplementation(defaultLifecycleFilterFunction);
+
+    const { getAllByRole, getByTestId } = await renderInTestApp(
+      <Wrapper>
+        <ToolExplorerContent showLifecycleFilter />
+      </Wrapper>,
+    );
+
+    fireEvent.click(getByTestId('lifecycle-picker-expand'));
+    await waitFor(() => {
+      expect(getAllByRole('option').map(o => o.textContent)).toEqual([
+        'experimental',
+      ]);
+    });
+  });
+
+  it('filters by lifecycle and updates tools displayed', async () => {
+    exploreApi.getTools.mockImplementation(defaultLifecycleFilterFunction);
+    const { getByText, getByTestId, getByRole, queryByText } =
+      await renderInTestApp(
+        <Wrapper>
+          <ToolExplorerContent showLifecycleFilter />
+        </Wrapper>,
+      );
+
+    await waitFor(() => {
+      expect(getByText('Lighthouse')).toBeInTheDocument();
+      expect(getByText('Tech Radar')).toBeInTheDocument();
+    });
+
+    fireEvent.click(getByTestId('lifecycle-picker-expand'));
+    fireEvent.click(getByRole('option', { name: 'experimental' }));
+
+    await waitFor(() => {
+      expect(getByRole('button', { name: 'experimental' })).toBeInTheDocument();
+      expect(getByText('Tech Radar')).toBeInTheDocument();
+      expect(queryByText('Lighthouse')).not.toBeInTheDocument();
+    });
+  });
+
+  it('uses query param to populate lifecycle filter', async () => {
+    exploreApi.getTools.mockImplementation(defaultLifecycleFilterFunction);
+    jest
+      .spyOn(URLSearchParams.prototype, 'getAll')
+      .mockReturnValue(['experimental']);
+
+    const { getByText, queryByText } = await renderInTestApp(
+      <Wrapper>
+        <ToolExplorerContent showLifecycleFilter />
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Lighthouse')).not.toBeInTheDocument();
+      expect(getByText('Tech Radar')).toBeInTheDocument();
+    });
   });
 });

--- a/workspaces/explore/plugins/explore/src/components/ToolExplorerContent/ToolExplorerContent.tsx
+++ b/workspaces/explore/plugins/explore/src/components/ToolExplorerContent/ToolExplorerContent.tsx
@@ -13,65 +13,174 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-import React from 'react';
-import useAsync from 'react-use/esm/useAsync';
-import { ToolCard } from '../ToolCard';
+import React, { useEffect, useState } from 'react';
+import useAsyncFn from 'react-use/esm/useAsyncFn';
+import { useSearchParams } from 'react-router-dom';
 import {
   Content,
   ContentHeader,
-  EmptyState,
   ItemCardGrid,
   Progress,
   SupportButton,
   WarningPanel,
 } from '@backstage/core-components';
 import { useApi } from '@backstage/core-plugin-api';
+import { ToolCard } from './../ToolCard';
+import { ExploreTool } from '@backstage-community/plugin-explore-common';
+
+import TextField from '@material-ui/core/TextField';
+import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 import { exploreApiRef } from '../../api';
+import Autocomplete from '@material-ui/lab/Autocomplete';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
-const Body = () => {
-  const exploreApi = useApi(exploreApiRef);
+const useStyles = makeStyles((theme: Theme) => ({
+  filter: {
+    '& + &': {
+      marginTop: theme.spacing(2.5),
+    },
+  },
+  filters: {
+    padding: theme.spacing(2),
+    marginTop: theme.spacing(2),
+  },
+}));
 
-  const {
-    value: tools,
-    loading,
-    error,
-  } = useAsync(async () => {
-    return (await exploreApi.getTools())?.tools;
-  }, [exploreApi]);
-
-  if (loading) {
-    return <Progress />;
-  }
-
-  if (error) {
-    return <WarningPanel title="Failed to load tools" />;
-  }
-
-  if (!tools?.length) {
-    return (
-      <EmptyState
-        missing="info"
-        title="No tools to display"
-        description="You haven't added any tools yet."
-      />
-    );
-  }
-
+const Body = (props: {
+  tools: ExploreTool[];
+  objectFit?: 'cover' | 'contain';
+}) => {
   return (
     <ItemCardGrid>
-      {tools.map((tool, index) => (
-        <ToolCard key={index} card={tool} />
+      {props.tools.map((tool, index) => (
+        <ToolCard key={index} card={tool} objectFit={props.objectFit} />
       ))}
     </ItemCardGrid>
   );
 };
 
-export const ToolExplorerContent = (props: { title?: string }) => (
-  <Content noPadding>
-    <ContentHeader title={props.title ?? 'Tools'}>
-      <SupportButton>Discover the tools in your ecosystem.</SupportButton>
-    </ContentHeader>
-    <Body />
-  </Content>
-);
+export const ToolExplorerContent = (props: {
+  title?: string;
+  objectFit?: 'cover' | 'contain';
+  showTagsFilter?: boolean;
+  showLifecycleFilter?: boolean;
+}) => {
+  const showTagsFilter = props.showTagsFilter ?? false;
+  const showLifecycleFilter = props.showLifecycleFilter ?? false;
+  const showFilters = showTagsFilter || showLifecycleFilter;
+  const classes = useStyles();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const exploreApi = useApi(exploreApiRef);
+  const [filteredTags, setFilteredTags] = useState<string[]>(
+    searchParams.getAll('tags'),
+  );
+  const [filteredLifecycle, setFilteredLifecycle] = useState<string[]>(
+    searchParams.getAll('lifecycle'),
+  );
+
+  const handleTagsChange = (_event: React.ChangeEvent<{}>, value: any) => {
+    setFilteredTags(value);
+    setSearchParams({ tags: value }, { replace: true });
+  };
+
+  const handleLifecycleChange = (_event: React.ChangeEvent<{}>, value: any) => {
+    setFilteredLifecycle(value);
+    setSearchParams({ lifecycle: value }, { replace: true });
+  };
+
+  const [tools, fetchTools] = useAsyncFn(async () => {
+    return (
+      await exploreApi.getTools({
+        filter: { tags: filteredTags, lifecycle: filteredLifecycle },
+      })
+    )?.tools;
+  }, [exploreApi, filteredTags, filteredLifecycle]);
+
+  const [uniqueTagsAndLifecycle, fetchTagsAndLifeCycles] =
+    useAsyncFn(async () => {
+      const allTools = (await exploreApi.getTools())?.tools;
+      if (!allTools) {
+        return {
+          tags: [],
+          lifecycles: [],
+        };
+      }
+
+      const uniqueTags = new Set(allTools.map(tool => tool.tags ?? []).flat());
+      const uniqueLifecycle = new Set(
+        allTools.map(tool => tool.lifecycle ?? []).flat(),
+      );
+
+      return {
+        tags: Array.from(uniqueTags),
+        lifecycles: Array.from(uniqueLifecycle),
+      };
+    }, [exploreApi]);
+
+  useEffect(() => {
+    fetchTools();
+    fetchTagsAndLifeCycles();
+  }, [filteredTags, filteredLifecycle, fetchTagsAndLifeCycles, fetchTools]);
+
+  return (
+    <Content noPadding>
+      <ContentHeader title={props.title ?? 'Tools'}>
+        <SupportButton>Discover the tools in your ecosystem.</SupportButton>
+      </ContentHeader>
+      <Grid container>
+        {showFilters && (
+          <Grid item xs={12}>
+            <Paper className={classes.filters}>
+              {showTagsFilter && (
+                <Autocomplete
+                  multiple
+                  options={uniqueTagsAndLifecycle.value?.tags ?? []}
+                  className={classes.filter}
+                  onChange={handleTagsChange}
+                  id="tags-filter"
+                  popupIcon={<ExpandMoreIcon data-testid="tag-picker-expand" />}
+                  renderInput={params => (
+                    <TextField {...params} label="Tags" variant="outlined" />
+                  )}
+                />
+              )}
+              {showLifecycleFilter && (
+                <Autocomplete
+                  multiple
+                  options={uniqueTagsAndLifecycle.value?.lifecycles ?? []}
+                  className={classes.filter}
+                  onChange={handleLifecycleChange}
+                  id="lifecycle-filter"
+                  popupIcon={
+                    <ExpandMoreIcon data-testid="lifecycle-picker-expand" />
+                  }
+                  renderInput={params => (
+                    <TextField
+                      {...params}
+                      label="Lifecycle"
+                      variant="outlined"
+                    />
+                  )}
+                />
+              )}
+            </Paper>
+          </Grid>
+        )}
+        <Grid item xs={12}>
+          {(tools.loading || uniqueTagsAndLifecycle.loading) && <Progress />}
+          {(tools.error || uniqueTagsAndLifecycle.error) && (
+            <WarningPanel title="Failed to load tools" />
+          )}
+          {tools.value && tools.value.length === 0 && (
+            <WarningPanel title="No tools found" />
+          )}
+          {tools.value && (
+            <Body tools={tools.value} objectFit={props.objectFit} />
+          )}
+        </Grid>
+      </Grid>
+    </Content>
+  );
+};


### PR DESCRIPTION
## Hey, I just made a Pull Request!
In order to make the explore plugin frontend take advantage of tagging and lifecycle support provided by the backend, add in support for optionally filtering by tags and lifecycle in the frontend UI

![image](https://github.com/user-attachments/assets/093143a1-4350-4b0c-bbb6-b9ede8b7b9c0)
![image](https://github.com/user-attachments/assets/b56f6ee4-92ba-4161-8838-c7f04a8890a1)
![image](https://github.com/user-attachments/assets/27a7521c-e21c-4dad-8ed6-ecbf830f4663)


#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#creating-changesets))
- [x] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [x] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/community-plugins/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
